### PR TITLE
Propopal: extract decta-api client and services functionality to interfaces making them more test-friendly

### DIFF
--- a/api_card_order.go
+++ b/api_card_order.go
@@ -17,7 +17,16 @@ import (
 	"net/url"
 )
 
-// CardOrderAPIService CardOrderAPI service
+type ICardOrderAPIService interface {
+	GetOrdersList(ctx context.Context) ApiGetOrdersListRequest
+	GetOrdersListExecute(r ApiGetOrdersListRequest) ([]Order, *http.Response, error)
+	OrderCard(ctx context.Context) ApiOrderCardRequest
+	OrderCardExecute(r ApiOrderCardRequest) (*OrderCardResponse, *http.Response, error)
+	OrderGiftCard(ctx context.Context) ApiOrderGiftCardRequest
+	OrderGiftCardExecute(r ApiOrderGiftCardRequest) (*GiftOrderCardResponse, *http.Response, error)
+}
+
+// CardOrderAPIService cardOrderAPI service
 type CardOrderAPIService service
 
 type ApiGetOrdersListRequest struct {

--- a/api_cards.go
+++ b/api_cards.go
@@ -19,7 +19,44 @@ import (
 	"strings"
 )
 
-// CardsAPIService CardsAPI service
+type IApiUpdateStateRequest interface {
+	TokenHeader(tokenHeader string) IApiUpdateStateRequest
+	TokenSignature(tokenSignature string) IApiUpdateStateRequest
+	StatusChange(statusChange StatusChange) IApiUpdateStateRequest
+	RequestId(requestId string) IApiUpdateStateRequest
+	Execute() (*http.Response, error)
+}
+
+type ICardsAPIService interface {
+	AssignPin(ctx context.Context, ppan string) ApiAssignPinRequest
+	AssignPinExecute(r ApiAssignPinRequest) (*http.Response, error)
+	GetCardData1(ctx context.Context, ppan string) ApiGetCardData1Request
+	GetCardData1Execute(r ApiGetCardData1Request) (*CardData1ApiDto, *http.Response, error)
+	GetCardData2(ctx context.Context, ppan string) ApiGetCardData2Request
+	GetCardData2Execute(r ApiGetCardData2Request) (*CardData2ApiDto, *http.Response, error)
+	GetCardData3(ctx context.Context, ppan string) ApiGetCardData3Request
+	GetCardData3Execute(r ApiGetCardData3Request) (*CardData3HolderApiDto, *http.Response, error)
+	GetCardData4(ctx context.Context, ppan string) ApiGetCardData4Request
+	GetCardData4Execute(r ApiGetCardData4Request) (*Data4, *http.Response, error)
+	GetCardData5(ctx context.Context, ppan string) ApiGetCardData5Request
+	GetCardData5Execute(r ApiGetCardData5Request) (*CardData2ApiDto, *http.Response, error)
+	GetInfo(ctx context.Context, ppan string) ApiGetInfoRequest
+	GetInfoExecute(r ApiGetInfoRequest) (*CardInfo, *http.Response, error)
+	GetList(ctx context.Context) ApiGetListRequest
+	GetListExecute(r ApiGetListRequest) (*CardInfoDataArray, *http.Response, error)
+	GetTspSecret(ctx context.Context, ppan string) ApiGetTspSecretRequest
+	GetTspSecretExecute(r ApiGetTspSecretRequest) (*TspSecret, *http.Response, error)
+	RenewCard(ctx context.Context, ppan string) ApiRenewCardRequest
+	RenewCardExecute(r ApiRenewCardRequest) (*CardRenewInfo, *http.Response, error)
+	ReplaceCard(ctx context.Context, ppan string) ApiReplaceCardRequest
+	ReplaceCardExecute(r ApiReplaceCardRequest) (*CardInfo, *http.Response, error)
+	UpdateCardUserDefinedFields(ctx context.Context, ppan string) ApiUpdateCardUserDefinedFieldsRequest
+	UpdateCardUserDefinedFieldsExecute(r ApiUpdateCardUserDefinedFieldsRequest) (*http.Response, error)
+	UpdateState(ctx context.Context, ppan string) IApiUpdateStateRequest
+	UpdateStateExecute(r ApiUpdateStateRequest) (*http.Response, error)
+}
+
+// CardsAPIService cardsAPI service
 type CardsAPIService service
 
 type ApiAssignPinRequest struct {
@@ -1791,24 +1828,24 @@ type ApiUpdateStateRequest struct {
 }
 
 // URL64Encoded without padding Header part of JWS token
-func (r ApiUpdateStateRequest) TokenHeader(tokenHeader string) ApiUpdateStateRequest {
+func (r ApiUpdateStateRequest) TokenHeader(tokenHeader string) IApiUpdateStateRequest {
 	r.tokenHeader = &tokenHeader
 	return r
 }
 
 // URL64Encoded without padding Signature part of JWS
-func (r ApiUpdateStateRequest) TokenSignature(tokenSignature string) ApiUpdateStateRequest {
+func (r ApiUpdateStateRequest) TokenSignature(tokenSignature string) IApiUpdateStateRequest {
 	r.tokenSignature = &tokenSignature
 	return r
 }
 
-func (r ApiUpdateStateRequest) StatusChange(statusChange StatusChange) ApiUpdateStateRequest {
+func (r ApiUpdateStateRequest) StatusChange(statusChange StatusChange) IApiUpdateStateRequest {
 	r.statusChange = &statusChange
 	return r
 }
 
 // Request ID (UUID format)
-func (r ApiUpdateStateRequest) RequestId(requestId string) ApiUpdateStateRequest {
+func (r ApiUpdateStateRequest) RequestId(requestId string) IApiUpdateStateRequest {
 	r.requestId = &requestId
 	return r
 }
@@ -1826,7 +1863,7 @@ The request allows users to block, unblock and activate cards for selected PPAN.
 	@param ppan masked card number
 	@return ApiUpdateStateRequest
 */
-func (a *CardsAPIService) UpdateState(ctx context.Context, ppan string) ApiUpdateStateRequest {
+func (a *CardsAPIService) UpdateState(ctx context.Context, ppan string) IApiUpdateStateRequest {
 	return ApiUpdateStateRequest{
 		ApiService: a,
 		ctx:        ctx,

--- a/api_limits.go
+++ b/api_limits.go
@@ -18,7 +18,16 @@ import (
 	"strings"
 )
 
-// LimitsAPIService LimitsAPI service
+type ILimitsAPIService interface {
+	EditLimits(ctx context.Context, ppan string) ApiEditLimitsRequest
+	EditLimitsExecute(r ApiEditLimitsRequest) (*http.Response, error)
+	GetLimits(ctx context.Context, ppan string) ApiGetLimitsRequest
+	GetLimitsExecute(r ApiGetLimitsRequest) (*LimitsData, *http.Response, error)
+	GetLimitsRefData(ctx context.Context) ApiGetLimitsRefDataRequest
+	GetLimitsRefDataExecute(r ApiGetLimitsRefDataRequest) (*LimitsData, *http.Response, error)
+}
+
+// LimitsAPIService limitsAPI service
 type LimitsAPIService service
 
 type ApiEditLimitsRequest struct {

--- a/api_reminders.go
+++ b/api_reminders.go
@@ -18,7 +18,18 @@ import (
 	"strings"
 )
 
-// RemindersAPIService RemindersAPI service
+type IRemindersAPIService interface {
+	GetPinTryCounter(ctx context.Context, ppan string) ApiGetPinTryCounterRequest
+	GetPinTryCounterExecute(r ApiGetPinTryCounterRequest) (*PinTryCounterInfo, *http.Response, error)
+	RemindPanCvv(ctx context.Context, ppan string) ApiRemindPanCvvRequest
+	RemindPanCvvExecute(r ApiRemindPanCvvRequest) (*http.Response, error)
+	RemindPin(ctx context.Context, ppan string) ApiRemindPinRequest
+	RemindPinExecute(r ApiRemindPinRequest) (*http.Response, error)
+	ResetPinTryCounter(ctx context.Context, ppan string) ApiResetPinTryCounterRequest
+	ResetPinTryCounterExecute(r ApiResetPinTryCounterRequest) (*http.Response, error)
+}
+
+// RemindersAPIService remindersAPI service
 type RemindersAPIService service
 
 type ApiGetPinTryCounterRequest struct {

--- a/api_transactions.go
+++ b/api_transactions.go
@@ -19,7 +19,14 @@ import (
 	"strings"
 )
 
-// TransactionsAPIService TransactionsAPI service
+type ITransactionsAPIService interface {
+	CardTransactions(ctx context.Context, ppan string) ApiCardTransactionsRequest
+	CardTransactionsExecute(r ApiCardTransactionsRequest) (*TransactionInfoDataArray, *http.Response, error)
+	DoTransaction(ctx context.Context, ppan string) ApiDoTransactionRequest
+	DoTransactionExecute(r ApiDoTransactionRequest) (*TransactionInfo, *http.Response, error)
+}
+
+// TransactionsAPIService transactionsAPI service
 type TransactionsAPIService service
 
 type ApiCardTransactionsRequest struct {

--- a/client.go
+++ b/client.go
@@ -39,6 +39,15 @@ var (
 	queryDescape    = strings.NewReplacer("%5B", "[", "%5D", "]")
 )
 
+type IAPIClient interface {
+	GetCardOrderAPI() ICardOrderAPIService
+	GetCardsAPI() ICardsAPIService
+	GetLimitsAPI() ILimitsAPIService
+	GetRemindersAPI() IRemindersAPIService
+	GetTransactionsAPI() ITransactionsAPIService
+	GetConfig() *Configuration
+}
+
 // APIClient manages communication with the Decta API API v2.11
 // In most cases there should be only one, shared, APIClient.
 type APIClient struct {
@@ -51,21 +60,46 @@ type APIClient struct {
 
 	AuthorizationsAPI *AuthorizationsAPIService
 
-	CardOrderAPI *CardOrderAPIService
+	cardOrderAPI ICardOrderAPIService
 
-	CardsAPI *CardsAPIService
+	cardsAPI ICardsAPIService
 
 	ClientsAPI *ClientsAPIService
 
 	DectaSecureAPI *DectaSecureAPIService
 
-	LimitsAPI *LimitsAPIService
+	limitsAPI ILimitsAPIService
 
-	RemindersAPI *RemindersAPIService
+	remindersAPI IRemindersAPIService
 
 	TokenAPI *TokenAPIService
 
-	TransactionsAPI *TransactionsAPIService
+	transactionsAPI ITransactionsAPIService
+}
+
+// GetCardOrderAPI returns the cardsAPI service as ICardOrderAPIService
+func (c *APIClient) GetCardOrderAPI() ICardOrderAPIService {
+	return c.cardOrderAPI
+}
+
+// GetCardsAPI returns the cardsAPI service as ICardsAPIService
+func (c *APIClient) GetCardsAPI() ICardsAPIService {
+	return c.cardsAPI
+}
+
+// GetLimitsAPI returns the limitsAPI service as ILimitsAPIService
+func (c *APIClient) GetLimitsAPI() ILimitsAPIService {
+	return c.limitsAPI
+}
+
+// GetRemindersAPI returns the remindersAPI service as IRemindersAPIService
+func (c *APIClient) GetRemindersAPI() IRemindersAPIService {
+	return c.remindersAPI
+}
+
+// GetTransactionsAPI returns the remindersAPI service as ITransactionsAPIService
+func (c *APIClient) GetTransactionsAPI() ITransactionsAPIService {
+	return c.transactionsAPI
 }
 
 type service struct {
@@ -86,14 +120,14 @@ func NewAPIClient(cfg *Configuration) *APIClient {
 	// API Services
 	c.AccountsAPI = (*AccountsAPIService)(&c.common)
 	c.AuthorizationsAPI = (*AuthorizationsAPIService)(&c.common)
-	c.CardOrderAPI = (*CardOrderAPIService)(&c.common)
-	c.CardsAPI = (*CardsAPIService)(&c.common)
+	c.cardOrderAPI = (*CardOrderAPIService)(&c.common)
+	c.cardsAPI = (*CardsAPIService)(&c.common)
 	c.ClientsAPI = (*ClientsAPIService)(&c.common)
 	c.DectaSecureAPI = (*DectaSecureAPIService)(&c.common)
-	c.LimitsAPI = (*LimitsAPIService)(&c.common)
-	c.RemindersAPI = (*RemindersAPIService)(&c.common)
+	c.limitsAPI = (*LimitsAPIService)(&c.common)
+	c.remindersAPI = (*RemindersAPIService)(&c.common)
 	c.TokenAPI = (*TokenAPIService)(&c.common)
-	c.TransactionsAPI = (*TransactionsAPIService)(&c.common)
+	c.transactionsAPI = (*TransactionsAPIService)(&c.common)
 
 	return c
 }


### PR DESCRIPTION
This PR is a proposal for making **decta-api** lib more test-friendly by extracting some existing APIs to interfaces making them easily mockable.